### PR TITLE
t/*.t - use a distinct test file, with pid in it, for each test

### DIFF
--- a/Zlib.pm
+++ b/Zlib.pm
@@ -291,7 +291,7 @@ use Fcntl qw(SEEK_SET);
 use Symbol;
 use Tie::Handle;
 
-our $VERSION = "1.11";
+our $VERSION = "1.12";
 our $AUTOLOAD;
 our @ISA = qw(Tie::Handle);
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -10,7 +10,7 @@ sub ok
     print "not ok $no\n" unless $ok ;
 }
 
-my $name = "test.gz";
+my $name = "test_b$$.gz";
 
 print "1..17\n";
 

--- a/t/external.t
+++ b/t/external.t
@@ -70,7 +70,7 @@ ok(14, $@ =~ /^IO::Zlib::gzopen_external: mode 'xyz' is illegal /);
 # The following is a copy of the basic.t, shifted up by 14 tests,
 # the difference being that now we should be using the external gzip.
 
-my $name="test.gz";
+my $name="test_x$$.gz";
 
 my $hello = <<EOM ;
 hello world

--- a/t/getc.t
+++ b/t/getc.t
@@ -10,7 +10,7 @@ sub ok
     print "not ok $no\n" unless $ok ;
 }
 
-my $name = "test.gz";
+my $name = "test_gc$$.gz";
 
 print "1..10\n";
 

--- a/t/getline.t
+++ b/t/getline.t
@@ -10,7 +10,7 @@ sub ok
     print "not ok $no\n" unless $ok ;
 }
 
-my $name = "test.gz";
+my $name = "test_gl$$.gz";
 
 print "1..23\n";
 

--- a/t/large.t
+++ b/t/large.t
@@ -10,7 +10,7 @@ sub ok
     print "not ok $no\n" unless $ok ;
 }
 
-my $name = "test.gz";
+my $name = "test_l$$.gz";
 
 print "1..7\n";
 

--- a/t/tied.t
+++ b/t/tied.t
@@ -10,7 +10,7 @@ sub ok
     print "not ok $no\n" unless $ok ;
 }
 
-my $name = "test.gz";
+my $name = "test_t$$.gz";
 
 print "1..11\n";
 

--- a/t/uncomp1.t
+++ b/t/uncomp1.t
@@ -17,7 +17,7 @@ hello world
 this is a test
 EOM
 
-my $name = "test$$";
+my $name = "test_uc1$$";
 
 if (open(FH, ">$name"))
 {

--- a/t/uncomp2.t
+++ b/t/uncomp2.t
@@ -17,7 +17,7 @@ hello world
 this is a test
 EOM
 
-my $name = "test$$";
+my $name = "test_uc2$$";
 
 if (open(FH, ">$name"))
 {


### PR DESCRIPTION
This hardens the tests against parallel test runs, which are common when this is tested as part of the perl core.

This includes a version bump, but does not include a ChangeLog entry.

See also: https://github.com/Perl/perl5/pull/20643