### PR TITLE
Fix INSTALLDIRS option on newer perls

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,7 @@ my %options = (
     VERSION_FROM => "Zlib.pm",
     PREREQ_PM => { "Compress::Zlib" => 2.000 },
     SIGN => 1,
-    INSTALLDIRS  => $] >= 5.00903 ? "perl" : "site",
+    INSTALLDIRS  => ($] >= 5.009003 && $] < 5.012000) ? "perl" : "site",
     dist => { COMPRESS => "gzip", SUFFIX => "gz" }
 );
 


### PR DESCRIPTION
The INSTALLDIRS option needs to be set to `perl` only on the versions of perl where the they have priority over the site install directories. That is from 5.9.3 (the version IO::Zlib was added to core) to 5.12.0 (the version where the priorities were fixed).