### PR TITLE
Makefile.PL: Add LICENSE

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,6 +12,11 @@ my %options = (
     dist => { COMPRESS => "gzip", SUFFIX => "gz" }
 );
 
+if ($ExtUtils::MakeMaker::VERSION >= 6.31)
+{
+    $options{LICENSE} = 'perl_5';
+}
+
 if ($ExtUtils::MakeMaker::VERSION >= 6.50)
 {
     $options{META_MERGE} = {


### PR DESCRIPTION
[`CPAN::Meta::Spec`](https://metacpan.org/pod/CPAN::Meta::Spec#license) mandates that the `license` field be populated. Since `ExtUtil::MakeMaker` version 6.31, this can be done by passing `LICENSE` to `WriteMakefile()`.